### PR TITLE
updating to allow permanent disconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5
+
+Allowing explicit disconnection to the Imandra Semantic Server.
+
 ## 0.4.4
 
 Multifile stdout hanging fix for macOS systems.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "iml-vscode",
   "displayName": "Imandra IDE",
   "description": "Imandra (ReasonML/OCaml) reasoning studio",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "publisher": "aestheticintegration",
   "bugs": {
     "url": "https://github.com/aestheticintegration/iml-vscode/issues"

--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -8,8 +8,6 @@ import * as assert from "assert";
 import * as path from "path";
 import * as crypto from "crypto";
 
-let connectionForcedClosed: boolean = false;
-
 enum state {
   Start,
   Connecting,
@@ -414,10 +412,8 @@ export class ImandraServerConn implements vscode.Disposable {
         const line = this.buffer.getLine().trim();
         if (line === "") continue;
         try {
-          if (!connectionForcedClosed) {
-            const res = JSON.parse(line) as response.Res;
-            this.handleRes(res);
-          }
+          const res = JSON.parse(line) as response.Res;
+          this.handleRes(res);
         } catch (e) {
           console.log(`ERROR: could not parse message's line "${line}" as json`);
         }
@@ -719,7 +715,6 @@ export class ImandraServerConn implements vscode.Disposable {
         if (res.v !== CUR_PROTOCOL_VERSION) {
           console.log(`error: imandra-server has version ${res.v}, not ${CUR_PROTOCOL_VERSION} as expected`);
           this.dispose(new WrongVersion(res.v));
-          connectionForcedClosed = true;
         }
         return;
       }


### PR DESCRIPTION
When developing sometimes - particularly with multifile examples, it really hammers the battery having imandra running. Sometimes good to develop with just merlin and then explicitly restart the server. This allows the command "disconnect semantic server" to switch it off - can be restarted then with an explicit restart.